### PR TITLE
Customizable installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,28 @@ This contains scripts to automate the installation of GNAT Community.
 
 Launch the script install_package.sh:
 
-``` sh install_package.sh  <path_to_package>  <target_dir> ```
+``` sh install_package.sh  <path_to_package>  <target_dir> [<components>]```
 
 ## On Windows
 
 From this directory, launch install_package.bat:
 
-``` install_package.bat  <path_to_package>  <target_dir> ```
+``` install_package.bat  <path_to_package>  <target_dir> [<components]```
+
+## Customization
+
+`<components>` is an optional argument which specifies a comma-separated
+list of components to install. This is useful if you don't want to install
+the entire package, but want to instead only install a specific subset of
+components that are available in the package.
+
+If the `<components>` argument is not specified then by default the entire
+package is installed.
+
+The list is comma-separated without spaces. For example,
+`com.adacore.spark2014_discovery` will only install the SPARK 2014 Discovery
+component, and `com.adacore.spark2014_discovery,com.adacore.gnat` will install
+both the SPARK tools and the GNAT compiler.
+
+The names of the components that are available for installation depends on
+the package you are installing.

--- a/install_package.bat
+++ b/install_package.bat
@@ -18,4 +18,4 @@ if exist %target% (
    exit /B 1
 )
 
-%package% --script install_script.qs InstallPrefix="%target% Components="%components%"
+%package% --script install_script.qs InstallPrefix="%target%" Components="%components%"

--- a/install_package.bat
+++ b/install_package.bat
@@ -4,17 +4,18 @@ setlocal
 set len=0
 for %%x in (%*) do set /A len+=1
 
-if not %len% == 2 (
-   echo Usage: install_package.bat  package  install_dir
+if %len% NEQ 2 if %len% NEQ 3 (
+   echo Usage: install_package.bat  package  install_dir [components]
    exit /B 1
 )
 
 set package=%1
 set target=%2
+set components=%3
 
 if exist %target% (
    echo Target directory already exists
    exit /B 1
 )
 
-%package% --script install_script.qs InstallPrefix="%target%
+%package% --script install_script.qs InstallPrefix="%target% Components="%components%"

--- a/install_package.sh
+++ b/install_package.sh
@@ -3,13 +3,14 @@
 script_dir=$(dirname $0)
 
 # Validate the number of arguments
-if [ "$#" -ne 2 ] ; then
-  echo "Usage: $0 <package_file> <target_directory>" >&2
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ] ; then
+  echo "Usage: $0 <package_file> <target_directory> [<components>]" >&2
   exit 1
 fi
 
 package_file=$1
 target=$2
+components=$3
 
 install_darwin() {
   # Create a mountpoint
@@ -23,7 +24,8 @@ install_darwin() {
   base=` basename $package_file | cut -d'.' -f1 `
   $mountpoint/$base.app/Contents/MacOS/$base \
      --script $script_dir/install_script.qs \
-     InstallPrefix="$target"
+     InstallPrefix="$target" \
+     Components="$components"
 
   umount $mountpoint
   rm -rf $mountpoint
@@ -34,7 +36,8 @@ install_linux() {
   "$package_file" \
      --script $script_dir/install_script.qs \
      --platform minimal \
-     InstallPrefix="$target"
+     InstallPrefix="$target" \
+     Components="$components"
 }
 
 # Make sure the target is nonexistent or empty

--- a/install_script.qs
+++ b/install_script.qs
@@ -1,4 +1,5 @@
 var install_dir = installer.value("InstallPrefix")
+var components  = installer.value("Components")
 
 function Controller() {
     installer.autoRejectMessageBoxes();
@@ -22,6 +23,15 @@ Controller.prototype.TargetDirectoryPageCallback = function()
 }
 
 Controller.prototype.ComponentSelectionPageCallback = function() {
+    if ((components != null) && (components != "")) {
+        var page = gui.currentPageWidget();
+
+        page.deselectAll();
+        complist = components.split(",");
+        for (var i = 0; i < complist.length; i++) {
+            page.selectComponent(complist[i]);
+        }
+    }
     gui.clickButton(buttons.NextButton);
 }
 


### PR DESCRIPTION
These changes allow the user to customize the installation by specifying the exact set of components that they want to install. This is useful to, for example, install only the SPARK 2014 toolset without installing GNAT and everything else.

The set of components to install is specified as an optional third argument to the `install_package` scripts, which specifies the components as a comma-separated list (no spaces). E.g. `com.adacore.gnat` specifies the GNAT component. 

These changes are backwards compatible with the existing behaviour. If this new argument is omitted, then all components are installed.

Here's an example of using this script to install only the SPARK 2014 Discovery component from GNAT Community 2019 to `~/opt/GNAT/2019`:

```
install_script.sh gnat-community-2019-20190517-x86_64-linux-bin ~/opt/GNAT/2019 com.adacore.spark2014_discovery
```